### PR TITLE
テキスト教材のCSVインポート機能を実装(エラーあり）

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,6 @@ module TeamProject
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
     config.time_zone = 'Asia/Tokyo'
-    config.
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module TeamProject
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
     config.time_zone = 'Asia/Tokyo'
+    config.
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2021_03_26_160802) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,13 +18,13 @@ end
 
 
 require "csv"
-
-Text.destroy_all
 class ImportCsv
+  Text.destroy_all #データの初期化
   # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)
     # インポートするデータを格納するための空配列
     list = []
+
     # CSVファイルからインポートしたデータを格納
     CSV.foreach(path, headers: true) do |row|
       list << row.to_h
@@ -35,7 +35,8 @@ class ImportCsv
 
   def self.text_data
     # importメソッドを呼び出し、テキストデータの配列を生成
-    list = import('db/csv_data/text_data')
+    list = import('db/csv_data/text_data.csv')
+    # row["genre"].to_i
 
     puts "インポート処理を開始"
     Text.create!(list)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,3 +15,17 @@ User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORD
   puts "ユーザーの初期データインポートに成功しました。"
 end
+
+# CSVデータのパスを引数として受け取り、インポート処理を実行
+require "csv"
+class ImportCsv
+  def self.import(path)
+    CSV.foreach(path, headers: true) do |row|
+      Text.create!(
+        genre: row["genre"], # CSVデータのgenre列の情報を指定して読み込む
+        title: row["title"], # CSVデータのtitle列の情報を指定して読み込む
+        contnent: row["contnent"] # CSVデータのcontent列の情報を指定して読み込む
+      )
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,17 +16,28 @@ User.find_or_create_by!(email: EMAIL) do |user|
   puts "ユーザーの初期データインポートに成功しました。"
 end
 
-# CSVデータのパスを引数として受け取り、インポート処理を実行
+
 require "csv"
 class ImportCsv
+  # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)
-    Text.destroy_all
+    # インポートするデータを格納するための空配列
+    list = []
+    # CSVファイルからインポートしたデータを格納
     CSV.foreach(path, headers: true) do |row|
-      Text.create!(
-        genre: row["genre"], # CSVデータのgenre列の情報を指定して読み込む
-        title: row["title"], # CSVデータのtitle列の情報を指定して読み込む
-        contnent: row["contnent"] # CSVデータのcontent列の情報を指定して読み込む
-      )
+      list << row.to_h
     end
+    # メソッドの戻り値をインポートしたデータの配列とする
+    list
   end
+
+  def self.text_data
+    # importメソッドを呼び出し、テキストデータの配列を生成
+    list = import('db/csv_data/text_data')
+
+    puts "インポート処理を開始"
+    Text.create!(list)
+    puts "インポート完了!!"
+  end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,6 +20,7 @@ end
 require "csv"
 class ImportCsv
   def self.import(path)
+    Text.destroy_all
     CSV.foreach(path, headers: true) do |row|
       Text.create!(
         genre: row["genre"], # CSVデータのgenre列の情報を指定して読み込む

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,8 @@ end
 
 
 require "csv"
+
+Text.destroy_all
 class ImportCsv
   # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)


### PR DESCRIPTION


## issue 番号

close #9

## 実装内容

- `db/seeds.rb`にテキスト教材のCSVを読み込む処理を追加
- `application.rb`の記述一部削除と`Text.destroy_all`の追加
- importクラスメソッドの修正、text_dataクラスメソッドの新規作成
- row["genre"].to_iを挿入（現時点ではコメントアウト）

## 参考資料

  - [CSVデータインポート機能](https://www.yanbaru-code.com/texts/217)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
コンソールで、
```
require_relative "db/seeds.rb"
ImportCsv.text_data
```
を実行したところ、

```
ArgumentError ('1' is not a valid genre)
```

と出てしまいます。エラーがあるのでまだ完了しておりませんが、取り急ぎプルリクを出します。
