### PR TITLE
ナビバーの修正（元のアプリに近づける）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+@import 'bootstrap/scss/bootstrap';
 .base-container {
   @extend .container-fluid;
   max-width: var(--breakpoint-lg);
@@ -27,7 +28,7 @@ body {
  *= require_self
  */
 
-@import 'bootstrap/scss/bootstrap';
+
 .navbar-nav {
   font-size: 15px;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
     <a class="navbar-brand" href="#">
-      <img width="240" src="/assets/yanbaru_logo-82873a179717b956922e2b075eaf01c24deadc0c50b2028003ebcd81b29e3d8e.png">
+      <img width="240" src="https://d5izmuz0mcjzz.cloudfront.net/yanbaru_expert_logo.png">
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,86 +1,90 @@
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
-  <a class="navbar-brand" href="#">やんばるエキスパート</a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  <div class="collapse navbar-collapse  " id="navbarNavAltMarkup">
-    <ul class="navbar-nav " >
-      <%# Ruby %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Ruby
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">Ruby/Railsテキスト教材</a>
-          <a class="dropdown-item" href="#">Ruby/Rails動画教材</a>
-          <a class="dropdown-item" href="#">AWSテキスト教材</a>
-          <a class="dropdown-item" href="#">よくある質問集</a>
-          <a class="dropdown-item" href="#">チャレンジ問題集</a>
-        </div>
-      </li>
-      <%# PHP %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          PHP
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">PHPテキスト教材</a>
-          <a class="dropdown-item" href="#">PHP動画教材</a>
-        </div>
-      </li>
-      <%# デザイン講座 %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          デザイン講座
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">デザインツールの使い方</a>
-          <a class="dropdown-item" href="#">実案件の取り方</a>
-          <a class="dropdown-item" href="#">デザインのマーケティング戦略</a>
-        </div>
-      </li>
-      <%# 勉強会 %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          勉強会
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">全ての勉強会</a>
-          <a class="dropdown-item" href="#">プログラミング勉強会</a>
-        </div>
-      </li>
-      <%# マネタイズ講座 %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          マネタイズ講座
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">マーケティング講座</a>
-          <a class="dropdown-item" href="#">Lステップ講座</a>
-          <a class="dropdown-item" href="#">インスタ講座</a>
-        </div>
-      </li>
-      <li class="nav-item active">
-        <a class="nav-link" href="#">LINE</a>
-      </li>
-      <!-- マイページ -->
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          マイページ
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="#">進捗管理</a>
-          <% if user_signed_in? %>
-          <!-- ログイン時 -->
-            <%= link_to "アカウント編集", edit_user_registration_path, class: "dropdown-item"%>
-            <%= link_to "ログアウト", destroy_user_session_path, class: "dropdown-item", method: :delete, data: { confirm: "本当によろしいですか" } %>
-          <% else %>
-          <!-- 非ログイン時 -->
-          <%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %>
-          <%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %>
-          <% end %>
-        </div>
-      </li>
-    </ul>
-  </div>
-</nav>
+<div class="container">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
+    <a class="navbar-brand" href="#">
+      <img width="240" src="/assets/yanbaru_logo-82873a179717b956922e2b075eaf01c24deadc0c50b2028003ebcd81b29e3d8e.png">
+    </a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse justify-content-center" id="navbarNavAltMarkup">
+      <ul class="navbar-nav">
+        <%# Ruby %>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Ruby
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">Ruby/Railsテキスト教材</a>
+            <a class="dropdown-item" href="#">Ruby/Rails動画教材</a>
+            <a class="dropdown-item" href="#">AWSテキスト教材</a>
+            <a class="dropdown-item" href="#">よくある質問集</a>
+            <a class="dropdown-item" href="#">チャレンジ問題集</a>
+          </div>
+        </li>
+        <%# PHP %>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            PHP
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">PHPテキスト教材</a>
+            <a class="dropdown-item" href="#">PHP動画教材</a>
+          </div>
+        </li>
+        <%# デザイン講座 %>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            デザイン講座
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">デザインツールの使い方</a>
+            <a class="dropdown-item" href="#">実案件の取り方</a>
+            <a class="dropdown-item" href="#">デザインのマーケティング戦略</a>
+          </div>
+        </li>
+        <%# 勉強会 %>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            勉強会
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">全ての勉強会</a>
+            <a class="dropdown-item" href="#">プログラミング勉強会</a>
+          </div>
+        </li>
+        <%# マネタイズ講座 %>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            マネタイズ講座
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">マーケティング講座</a>
+            <a class="dropdown-item" href="#">Lステップ講座</a>
+            <a class="dropdown-item" href="#">インスタ講座</a>
+          </div>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="#">LINE</a>
+        </li>
+        <!-- マイページ -->
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            マイページ
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">進捗管理</a>
+            <% if user_signed_in? %>
+            <!-- ログイン時 -->
+              <%= link_to "アカウント編集", edit_user_registration_path, class: "dropdown-item"%>
+              <%= link_to "ログアウト", destroy_user_session_path, class: "dropdown-item", method: :delete, data: { confirm: "本当によろしいですか" } %>
+            <% else %>
+            <!-- 非ログイン時 -->
+              <%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %>
+              <%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %>
+            <% end %>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -63,9 +63,6 @@
             <a class="dropdown-item" href="#">インスタ講座</a>
           </div>
         </li>
-        <li class="nav-item active">
-          <a class="nav-link" href="#">LINE</a>
-        </li>
         <!-- マイページ -->
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -63,23 +63,24 @@
       <li class="nav-item active">
         <a class="nav-link" href="#">LINE</a>
       </li>
-      <% if user_signed_in? %>
-        <!-- ログイン時 -->
-        <li class="nav-item active">
-          <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active"%>
-        </li>
-        <li class="nav-item active">
-          <%= link_to "ログアウト", destroy_user_session_path, class: "nav-item nav-link active", method: :delete, data: { confirm: "本当によろしいですか" } %>
-        </li>
-      <% else %>
-        <!-- 非ログイン時 -->
-        <li class="nav-item active">
-          <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-        </li>
-        <li class="nav-item active">
-          <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
-        </li>
-      <% end %>
+      <!-- マイページ -->
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle nav-item nav-link active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          マイページ
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <a class="dropdown-item" href="#">進捗管理</a>
+          <% if user_signed_in? %>
+          <!-- ログイン時 -->
+            <%= link_to "アカウント編集", edit_user_registration_path, class: "dropdown-item"%>
+            <%= link_to "ログアウト", destroy_user_session_path, class: "dropdown-item", method: :delete, data: { confirm: "本当によろしいですか" } %>
+          <% else %>
+          <!-- 非ログイン時 -->
+          <%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %>
+          <%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %>
+          <% end %>
+        </div>
+      </li>
     </ul>
   </div>
 </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <link rel="stylesheets" href="application.scss">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <link rel="stylesheets" href="application.scss">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>


### PR DESCRIPTION
## issue 番号

close #37

## 実装内容
- ナビバーの「やんばるエキスパート」のロゴ変更→　ロゴ写真の素材があれば提供頂きたいです。
- ナビバーを中央揃えとする
- マイページのタブボタン設定

## 参考資料

-  [【公式】Bootstrap（Navbar）](https://getbootstrap.jp/docs/4.5/components/navbar/)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
- ナビバーの「やんばるエキスパート」のロゴについて、素材があれば提供頂きたいです。
現状、デベロッパーツールに書いてあった、`img src=""`を書いてますが、反映されてません。
