### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'devise-bootstrap-views', '~> 1.0'
 
 gem 'activeadmin'
 gem 'kaminari'
+gem 'redcarpet'
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -252,6 +253,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
@@ -264,6 +266,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,9 @@
 class TextsController < ApplicationController
-
   def index
     @texts = Text.where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc)
+  end
+
+  def show
+    @text = Text.find(params[:id])
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,52 @@
+module MarkdownHelper
+  def markdown(text)
+    options = {
+      filter_html: true,     # htmlを出力しない
+      hard_wrap: true,     # マークダウン中の空行をhtmlに置き換え
+      space_after_headers: true, # # と文字の間にスペースを要求
+    }
+
+    extensions = {
+      autolink: true,  # <>で囲まれてなくてもリンクを認識
+      space_after_headers: true,
+      no_intra_emphasis: true,  # 単語中の強調を認識しない
+      fenced_code_blocks: true,  # フェンスのあるコードブロックを認識
+      strikethrough: true,  # ~ 2つで取り消し線
+      tables: true,  # テーブルを認識
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      underline: true,  # 斜線(* *)
+      highlight: true,  # ハイライト(== ==)
+      quote: true,  # 引用符(" ")
+      footnotes: true,  # 脚注( ^[1] )
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+
+    markdown.render(text).html_safe
+  end
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(":")[0]
+      case language.to_s
+      when "rb"
+        lang = "ruby"
+      when "yml"
+        lang = "yaml"
+      when "css"
+        lang = "css"
+      when "html"
+        lang = "html"
+      when ""
+        lang = "md"
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,36 +1,8 @@
 module MarkdownHelper
-  def markdown(text)
-    options = {
-      filter_html: true,     # htmlを出力しない
-      hard_wrap: true,     # マークダウン中の空行をhtmlに置き換え
-      space_after_headers: true, # # と文字の間にスペースを要求
-    }
-
-    extensions = {
-      autolink: true,  # <>で囲まれてなくてもリンクを認識
-      space_after_headers: true,
-      no_intra_emphasis: true,  # 単語中の強調を認識しない
-      fenced_code_blocks: true,  # フェンスのあるコードブロックを認識
-      strikethrough: true,  # ~ 2つで取り消し線
-      tables: true,  # テーブルを認識
-      hard_wrap: true,
-      xhtml: true,
-      lax_html_blocks: true,
-      underline: true,  # 斜線(* *)
-      highlight: true,  # ハイライト(== ==)
-      quote: true,  # 引用符(" ")
-      footnotes: true,  # 脚注( ^[1] )
-    }
-
-    renderer = Redcarpet::Render::HTML.new(options)
-    markdown = Redcarpet::Markdown.new(renderer, extensions)
-
-    markdown.render(text).html_safe
-  end
-
   class HTMLwithCoderay < Redcarpet::Render::HTML
     def block_code(code, language)
-      language = language.split(":")[0]
+      language = language.split(":")[0] if language.present?
+
       case language.to_s
       when "rb"
         lang = "ruby"
@@ -48,5 +20,25 @@ module MarkdownHelper
 
       CodeRay.scan(code, lang).div
     end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
           Ruby
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="texts">Ruby/Railsテキスト教材</a>
+          <a class="dropdown-item" href="/texts">Ruby/Railsテキスト教材</a>
           <a class="dropdown-item" href="/movies">Ruby/Rails動画教材</a>
           <a class="dropdown-item" href="#">AWSテキスト教材</a>
           <a class="dropdown-item" href="#">よくある質問集</a>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @text.title %></h1>
+<p><%= markdown(@text.content) %></p>


### PR DESCRIPTION
close #16 

## 実装内容
- 一覧ページから詳細ページに移動できるようにする
- 詳細ページの実装
  - 「内容（content）」は Markdown に対応した表示ができるようにすること
  - スタイルはデフォルトのままでOKです
  - 「読破済み」機能は別タスクとする

## 参考資料
- Markdownに対応した表示
  - [[Rails] Markdown形式で入力できるようにしてみた（シンタックスハイライトも対応）](https://qiita.com/hkengo/items/978ea1874cf7e07cdbfc)
  -  [vmg/redcarpet: The safe Markdown parser, reloaded. - GitHub](https://github.com/vmg/redcarpet)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認